### PR TITLE
Parse CSS classes more acurrately with AST parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-scoped-styles",
-    "version": "0.2.7",
+    "version": "0.2.81",
     "description": "Scoped styles for React components",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,7 @@
         "@types/webpack": "^4.4.24",
         "typescript": "^3.3.1"
     },
-    "dependencies": {}
+    "dependencies": {
+        "css-tree": "^1.0.0-alpha.33"
+    }
 }

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -3,12 +3,11 @@ import { LoaderContext } from './options';
 
 export default function scriptLoader(this: LoaderContext, source: string): string {
     const { globalsPrefix = 'app' } = this.query;
-    const isExternal = !this.resourcePath.startsWith(this.rootContext);
 
     const classExprRegex = /classname:\s(["'].*?["']|.*?\))/gi;
     const classStringRegex = new RegExp(`['|"](.*?)['|"]`, 'g')
 
-    if (isExternal || !source.match(classExprRegex)) {
+    if (!source.match(classExprRegex)) {
         return source;
     }
 

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -17,6 +17,7 @@ export default function scriptLoader(this: LoaderContext, source: string): strin
     return source.replace(classExprRegex, classExpr => {
         return classExpr.replace(classStringRegex, (_match, classNames) => {
             const uniqueClassNames = classNames.split(' ')
+                .filter(Boolean)
                 .map((className: string) => {
                     const containsPrefix = className.startsWith(`${globalsPrefix}-`);
                     const uniqueClassName = `${dirName}-${dirHash}-${className}`;


### PR DESCRIPTION
Use `css-tree` parser to target only class selectors in CSS. This fixes a lot of problems ones and forever

- No more false positives in decimal property values. They was detected as classes because of `.`
- Allow absent trailing semicolon in last rule in declaration. This have to work as it is valid by CSS spec
- Better code base flexibility for future features, e.g.: animation names scoping, etc.

Resolves https://github.com/featurematrix/react-scoped-styles/issues/4

@nairinarinyan please build from TypeScript locally and try to make it run successfully. I am not a "friend" of TypeScript and tested it only in pure JavaScript directly in `node_modules`