### PR TITLE
ClassName cannot match if compressed

### DIFF
--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -4,7 +4,7 @@ import { LoaderContext } from './options';
 export default function scriptLoader(this: LoaderContext, source: string): string {
     const { globalsPrefix = 'app' } = this.query;
 
-    const classExprRegex = /classname:\s(["'].*?["']|.*?\))/gi;
+    const classExprRegex = /classname:\s*(["'].*?["']|.*?\))/gi;
     const classStringRegex = new RegExp(`['|"](.*?)['|"]`, 'g')
 
     if (!source.match(classExprRegex)) {


### PR DESCRIPTION
When I use the prod environment build, It will be renewed

The create-react-app version I use is: 3.0.1