### PR TITLE
feat(regex): remove hyphen from regex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scoped-styles",
-  "version": "0.2.81",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/script-loader.ts
+++ b/src/script-loader.ts
@@ -4,7 +4,7 @@ import { LoaderContext } from './options';
 export default function scriptLoader(this: LoaderContext, source: string): string {
     const { globalsPrefix = 'app' } = this.query;
     const prefix = Array.isArray(globalsPrefix) ? globalsPrefix : [globalsPrefix];
-    const prefixRegex = new RegExp(`^(${prefix.join('|')})-`);
+    const prefixRegex = new RegExp(`^(${prefix.join('|')})`);
 
     const classExprRegex = /classname:\s(["'].*?["']|.*?\))/gi;
     const classStringRegex = new RegExp(`['|"](.*?)['|"]`, 'g')

--- a/src/style-loader.ts
+++ b/src/style-loader.ts
@@ -6,7 +6,7 @@ export default function styleLoader(this: LoaderContext, source: string): string
     const prefix = Array.isArray(globalsPrefix) ? globalsPrefix : [globalsPrefix];
 
     const classLineRegex = /(.*(\..*?)(?<!;)$)/gm;
-    const classRegex = new RegExp(`(?<=\\.)((?!(${prefix.join('|')})-)\\w+[\\w-]*\\b)`, 'g');
+    const classRegex = new RegExp(`(?<=\\.)((?!(${prefix.join('|')}))\\w+[\\w-]*\\b)`, 'g');
 
     if (!source.match(classLineRegex)) {
         return source;


### PR DESCRIPTION
some time globalsPrefix not use hyphen, like `react-modal`. they use underline.